### PR TITLE
feat: Convential commits are mandatory

### DIFF
--- a/.github/workflows/convential-commits-action.yml
+++ b/.github/workflows/convential-commits-action.yml
@@ -1,0 +1,12 @@
+name: Conventional Commits
+
+on: push
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: webiny/action-conventional-commits@v1.1.0

--- a/.github/workflows/convential-commits-action.yml
+++ b/.github/workflows/convential-commits-action.yml
@@ -7,6 +7,6 @@ jobs:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: webiny/action-conventional-commits@v1.1.0

--- a/git-conventional-commits.yaml
+++ b/git-conventional-commits.yaml
@@ -1,0 +1,43 @@
+---
+convention:
+  commitTypes:
+  - feat
+  - fix
+  - perf
+  - refactor
+  - style
+  - test
+  - build
+  - ops
+  - docs
+  - chore
+  - merge
+  - revert
+  commitScopes: []
+  releaseTagGlobPattern: v[0-9]*.[0-9]*.[0-9]*
+changelog:
+  commitTypes:
+  - feat
+  - fix
+  - perf
+  - merge
+  includeInvalidCommits: true
+  commitIgnoreRegexPattern: "^WIP "
+  headlines:
+    feat: Features
+    fix: Bug Fixes
+    perf: Performance Improvements
+    merge: Merges
+    breakingChange: BREAKING CHANGES
+
+  ## GitHub
+  # commitUrl: https://github.com/ACCOUNT/REPOSITORY/commit/%commit%
+  # commitRangeUrl: https://github.com/ACCOUNT/REPOSITORY/compare/%from%...%to%?diff=split
+
+  ## GitHub Issues
+  # issueRegexPattern: "#[0-9]+"
+  # issueUrl: https://github.com/ACCOUNT/REPOSITORY/issues/%issue%
+
+  ## Jira Issues
+  # issueRegexPattern: "[A-Z][A-Z0-9]+-[0-9]+"
+  # issueUrl: https://WORKSPACE.atlassian.net/browse/%issue%

--- a/git-conventional-commits.yaml
+++ b/git-conventional-commits.yaml
@@ -29,15 +29,3 @@ changelog:
     perf: Performance Improvements
     merge: Merges
     breakingChange: BREAKING CHANGES
-
-  ## GitHub
-  # commitUrl: https://github.com/ACCOUNT/REPOSITORY/commit/%commit%
-  # commitRangeUrl: https://github.com/ACCOUNT/REPOSITORY/compare/%from%...%to%?diff=split
-
-  ## GitHub Issues
-  # issueRegexPattern: "#[0-9]+"
-  # issueUrl: https://github.com/ACCOUNT/REPOSITORY/issues/%issue%
-
-  ## Jira Issues
-  # issueRegexPattern: "[A-Z][A-Z0-9]+-[0-9]+"
-  # issueUrl: https://WORKSPACE.atlassian.net/browse/%issue%


### PR DESCRIPTION
Workflow fill fail and local check will be done when dependencies are installed on machine. See git-conventional-commits
closes #3 